### PR TITLE
Починен sitemap: приоритеты страниц не проставлялись почти никому

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -189,28 +189,37 @@ export default defineConfig({
     hostname: 'https://wiki.catcraft.ru',
     transformItems: (items) => {
       return items.map((item) => {
-        if (item.url === '') {
+        // 🛑 VitePress отдаёт `url` БЕЗ ведущего слеша: `updates/8season/8_0_2`,
+        // а не `/updates/8season/8_0_2`. Поэтому проверки ниже, написанные как
+        // `includes('/updates/')`, не срабатывали ни разу за всё время: из 153
+        // страниц приоритет получали четыре, и три из них — по случайности,
+        // у гайдов кусок `/gameplay/` нашёлся в СЕРЕДИНЕ адреса
+        // (`guides/gameplay/rgb_nick`). Остальные 149 уходили в поиск с 0.5.
+        // Нормализуем один раз — дальше правила работают так, как написаны.
+        const url = item.url.startsWith('/') ? item.url : `/${item.url}`;
+
+        if (url === '/') {
           return { ...item, priority: 1.0, changefreq: 'daily' };
         }
 
-        if (item.url.includes('/updates/8season/')) {
+        if (url.includes('/updates/8season/')) {
           return { ...item, priority: 0.9, changefreq: 'weekly' };
         }
 
-        if (item.url.includes('/info/faq') || item.url.includes('/guides/')) {
+        if (url.includes('/info/faq') || url.includes('/guides/')) {
           return { ...item, priority: 0.8, changefreq: 'monthly' };
         }
 
-        if (item.url.includes('/gameplay/') || item.url.includes('/bestiary/')) {
+        if (url.includes('/gameplay/') || url.includes('/bestiary/')) {
           return { ...item, priority: 0.7, changefreq: 'monthly' };
         }
 
-        if (item.url.includes('/updates/')) {
+        if (url.includes('/updates/')) {
           return { ...item, priority: 0.5, changefreq: 'monthly' };
         }
 
         // История
-        if (item.url.includes('/history/')) {
+        if (url.includes('/history/')) {
           return { ...item, priority: 0.6, changefreq: 'monthly' };
         }
 


### PR DESCRIPTION
## Что было сломано

`sitemap.xml` — файл, который сайт отдаёт поисковикам: список всех страниц с подсказкой «эта важнее той». В `config.mjs` эта важность расставлялась: главная 1.0, свежие патчноуты 0.9, гайды 0.8, механики и бестиарий 0.7, история 0.6, старый архив 0.5.

Не работало ничего. VitePress отдаёт в `transformItems` адрес **без ведущего слеша** — `updates/8season/8_0_2`, а не `/updates/8season/8_0_2`. Все проверки написаны как `includes('/updates/')`, поэтому не срабатывали ни разу за всё время жизни этого кода.

Замер по собранному `sitemap.xml` **до** правки: из 152 страниц приоритет получили четыре. Три из них — по случайности: у гайдов адрес `guides/gameplay/rgb_nick`, и кусок `/gameplay/` нашёлся в **середине**. Остальные 148 уходили в поиск с дефолтными 0.5, включая свежие патчноуты и весь бестиарий.

## Что сделано

Одна строка: адрес нормализуется в начале обработчика, дальше правила работают так, как написаны, и читаются буквально. Нормализация идемпотентна — если VitePress в будущей версии начнёт слать слеш сам, ничего не сломается.

Сами правила не тронуты: починен механизм, а не политика.

## Проверено на собранном файле

Тот же `sitemap.xml`, до и после — 69 страниц из 152 сменили приоритет:

| было | стало | стр. | что это |
|---|---|---|---|
| 0.5 | 0.9 | 2 | патчноуты 8 сезона |
| 0.5 | 0.8 | 7 | гайды |
| 0.7 | 0.8 | 3 | гайды, которые совпадали случайно |
| 0.5 | 0.7 | 42 | механики и бестиарий |
| 0.5 | 0.6 | 15 | история сезонов |
| 1.0 | 1.0 | 1 | главная |
| 0.5 | 0.5 | 82 | старые патчноуты (70) и `info` кроме FAQ (12) |

## Требует твоего решения, в этот PR не входит

Из таблицы видно: условие `includes('/info/faq')` покрывает **ровно одну страницу**. «Правила», «Законы», «Администрация», «Донатик», «Брендбук» и ещё 7 страниц `info` остаются на 0.5 — наравне с архивом патчноутов 2022 года.

Похоже на недосмотр автора, но это решение про важность страниц, а не починка механизма. Скажи — заменю `'/info/faq'` на `'/info/'` одной строкой.

## Насколько это вообще больно

Умеренно. Google подсказку `priority` давно почти игнорирует, сайт от неё не ломался и в выдаче не падал. Ценность в том, что мёртвый код перестал выглядеть работающим: следующий, кто придёт настраивать приоритеты, увидит результат своих правок.

## Гейт

- `npm run docs:build` — зелёный
- `npm run check-descriptions` — страниц из этого PR в выводе нет
- Удалённых и переименованных `.md` нет
- Кредов в диффе нет
- Вёрстка: правка не влияет ни на одну страницу сайта, меняется только генерируемый `sitemap.xml` — проверено сравнением файла до и после
