### PR TITLE
Приоритеты раздела info в sitemap: разложены по тому, зачем приходят

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -63,6 +63,28 @@ const adhdVideosPlugin = {
   }
 }
 
+// Важность страниц для поисковиков (sitemap, поле priority ниже).
+//
+// Разложено по тому, ЗАЧЕМ человек приходит на страницу из поиска, а не по
+// тому, где она лежит в дереве. Хочешь поменять — правь эти два списка,
+// остальное считается по разделам.
+
+// За этим приходят чаще всего: человек выбирает, заходить ли на сервер,
+// и человек, которого касаются правила. Плюс нормативка живых игроков.
+const SEARCH_ENTRY = [
+  '/info/faq',        // как зайти, версия, что за сервер
+  '/info/guide',      // гайд для новичка
+  '/info/rules/',     // правила и законы
+];
+
+// Служебное: нужно редко, целенаправленно из поиска не ищется, ссылок
+// внутри сайта почти нет (брендбук и «для медиа» — по одной и по нулю).
+const SERVICE_PAGES = [
+  '/info/brandbook',
+  '/info/for_media',
+  '/info/prefixes',
+];
+
 export default defineConfig({
   title: "Кошкокрафт",
   lang: 'ru',
@@ -206,7 +228,17 @@ export default defineConfig({
           return { ...item, priority: 0.9, changefreq: 'weekly' };
         }
 
-        if (url.includes('/info/faq') || url.includes('/guides/')) {
+        if (SEARCH_ENTRY.some((p) => url.startsWith(p))) {
+          return { ...item, priority: 0.9, changefreq: 'monthly' };
+        }
+
+        if (SERVICE_PAGES.some((p) => url.startsWith(p))) {
+          return { ...item, priority: 0.6, changefreq: 'monthly' };
+        }
+
+        // Остальная справка: донат, моды, карта, баны, администрация, фермы
+        // и все гайды. За этим приходят целенаправленно, но реже.
+        if (url.startsWith('/info/') || url.includes('/guides/')) {
           return { ...item, priority: 0.8, changefreq: 'monthly' };
         }
 


### PR DESCRIPTION
Продолжение #51. Там был починен механизм — выяснилось, что правило покрывало ровно одну страницу: условие написано как `/info/faq`. Остальные двенадцать страниц раздела оставались на дефолтных 0.5, наравне с архивом патчноутов 2022 года. Среди них — правила сервера и гайд для новичка.

## Как раскладывал

Не по месту в дереве, а по тому, **зачем человек открывает страницу из поиска**.

Опора не только на здравый смысл. Посчитаны входящие внутренние ссылки по всем `.md` и `.vue` репозитория — это честный сигнал того, насколько страница нужна изнутри сайта:

| ссылок | страница |
|---|---|
| 8 | `/info/donate` |
| 4 | `/info/guide` |
| 3 | `/info/rules/laws`, `/info/mods` |
| 2 | `/info/rules/rules`, `/info/faq` |
| 1 | `/info/prefixes`, `/info/map`, `/info/farm`, `/info/brandbook`, `/info/admins` |
| 0 | `/info/for_media`, `/info/banlist` |

Дальше поправлено на то, чего внутренние ссылки не видят: правила и FAQ линкуются редко просто потому, что они и так в навбаре, — а ищут их постоянно.

## Что получилось

**0.9 — `faq`, `guide`, `rules`, `laws`**
Вход новичка (решает, заходить ли на сервер) и нормативка живых игроков.

**0.8 — `donate`, `mods`, `map`, `banlist`, `admins`, `farm`**
Справка, за которой приходят целенаправленно, но реже.

**0.6 — `brandbook`, `for_media`, `prefixes`**
Служебное: из поиска не ищется, внутри сайта почти не линкуется.

Списки лежат двумя массивами в начале `config.mjs` с пояснением — поменять состав можно, не разбираясь в остальном коде.

## Проверено

Собранный `sitemap.xml` сравнён с тем, что **прямо сейчас отдаёт прод**. Изменились ровно 13 страниц, все в `/info/`:

```
0.5 → 0.9   /info/guide, /info/rules/rules, /info/rules/laws
0.8 → 0.9   /info/faq
0.5 → 0.8   /info/donate, /info/mods, /info/map,
            /info/banlist, /info/admins, /info/farm
0.5 → 0.6   /info/brandbook, /info/for_media, /info/prefixes
```

Ни одна страница других разделов не задета. Итоговое распределение по 153 страницам: `1.0 — 1 · 0.9 — 6 · 0.8 — 15 · 0.7 — 42 · 0.6 — 19 · 0.5 — 70`.

Гейт: `docs:build` зелёный, `check-descriptions` без новых страниц, удалённых `.md` нет, кредов нет. Вёрстка не меняется — правка влияет только на генерируемый `sitemap.xml`.

## Важно про деплой

Этот PR обязан пройти сборку. `sitemap.xml` не лежит в репозитории — он генерируется во время деплоя, и без прогона новые приоритеты на прод не попадут.
